### PR TITLE
Devcontainer と lint/format 周りを最新化 (Python 3.13 / Ruff / 非 root)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,24 +1,23 @@
-# ベースイメージ
-FROM python:3.11-slim
+FROM python:3.13-slim
 
-# 必要な環境を更新・インストール
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 \
-    python3-pip \
-    python3-setuptools \
-    python3-venv \
-    build-essential \
-    curl \
-    wget \
-    git \
-    zip \
-    unzip \
-    vim \
-    iputils-ping \
-    net-tools \
-    software-properties-common \
+        build-essential \
+        curl \
+        git \
+        vim \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# pip インストール
-RUN pip3 install --no-cache-dir --upgrade pip setuptools wheel
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r /tmp/requirements.txt \
+    && rm /tmp/requirements.txt
+
+USER $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,26 +2,23 @@
   "name": "Python DevContainer",
   "build": {
     "dockerfile": "Dockerfile",
-    "context": "."
+    "context": ".."
   },
-
   "customizations": {
     "vscode": {
       "extensions": [
-        "wmaurer.change-case",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-python.debugpy",
+        "charliermarsh.ruff",
+        "ms-toolsai.jupyter",
         "mhutchie.git-graph",
         "streetsidesoftware.code-spell-checker",
         "ms-vsliveshare.vsliveshare",
-        "ms-python.python",
-        "ms-python.vscode-pylance",
-        "ms-toolsai.jupyter",
-        "donjayamanne.python-extension-pack",
-        "ms-python.black-formatter",
-        "ms-python.flake8",
+        "wmaurer.change-case",
         "esbenp.prettier-vscode"
       ]
     }
   },
-  "postCreateCommand": "pip install --root-user-action=ignore -r requirements.txt",
-  "remoteUser": "root"
+  "remoteUser": "vscode"
 }

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.gitignore
+.github
+.vscode
+.devcontainer
+.idea
+.pytest_cache
+__pycache__
+*.py[cod]
+*.egg-info
+.venv
+venv
+env
+.env
+README.md
+LICENSE

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 88
-extend-ignore = E203, W503

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,18 @@
 {
-  "cSpell.words": ["pytest", "wmaurer"]
+  "cSpell.words": [
+    "devcontainer",
+    "fizzbuzz",
+    "pyproject",
+    "pytest",
+    "ruff",
+    "wmaurer"
+  ],
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "explicit",
+      "source.organizeImports": "explicit"
+    }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 ## 特徴
 
-- **Python 3.11** を使用
+- **Python 3.13** を使用
 - あらかじめインストールされているツール:
   - `pytest`（テストフレームワーク）
-  - `flake8`（コードリントツール）
-  - `black`（コードフォーマッタ）
+  - `ruff`（リンタ兼フォーマッタ）
 - Devcontainer による一貫性のある開発環境
 - Docker ベースの隔離された環境で、設定の一貫性を保証
+- 非 root ユーザー (`vscode`) で動作し、マウントしたファイルの権限トラブルを回避
 - サンプルコードとリファレンス例の追加
   - Python の基本的な文法やデザインパターンをカバー
   - 詳細なテストケースを含む実装
@@ -22,7 +22,7 @@
 1. このリポジトリをクローンします:
 
    ```bash
-   git clone https://github.com/tomohiroJin/devcontainer-python.git -b feature/add-reference
+   git clone https://github.com/tomohiroJin/devcontainer-python.git
    cd devcontainer-python
    ```
 
@@ -46,21 +46,23 @@
 
 ### **リファレンスの内容**
 
-- `reference/basic`:
+- `src/reference/basic`:
   - **Python の基本文法**: 変数、関数、クラス、条件分岐、ループ、例外処理
   - 各実装には詳細なテストとコメント付きのコードが含まれています
-- `reference/patterns`:
+- `src/reference/patterns`:
   - **デザインパターンの実装例**:
     - Strategy パターン
-    - Observer パターン
+    - Observer パターン（`observer.py` と property を用いた `observer_property.py` の 2 種類）
     - Decorator パターン
     - Factory パターン
     - Template Method パターン
 
 ### **サンプルの内容**
 
-- `reference/samples`
-  - fizzbuzz
+- `src/hello_world`
+  - Hello, World! を出力するだけの最小サンプル
+- `src/reference/samples/fizzbuzz`
+  - FizzBuzz 実装
 
 ## 使用方法
 
@@ -79,7 +81,7 @@ pytest
 特定のテストファイルのみを実行したい場合は、ファイルパスを指定します。
 
 ```bash
-pytest tests/reference/basic/test_conditions.py
+pytest tests/reference/basic/test_conditionals_and_loops.py
 ```
 
 #### **テストの進捗と詳細を確認**
@@ -106,43 +108,26 @@ pytest -k "fizzbuzz"
 pytest -s
 ```
 
-#### **テスト結果をリポート形式で保存**
-
-`pytest-html`プラグインを使用して、HTML 形式のレポートを生成します。
-
-```bash
-pip install pytest-html
-pytest --html=report.html
-```
-
 ---
 
-### **2. コード品質チェック**
+### **2. コード品質チェック (Ruff)**
 
-`flake8`を使用してコードの品質を確認します。以下のオプションを組み合わせることで、詳細な結果を得ることができます。
+`ruff` を使用してコードの品質を確認します。設定は `pyproject.toml` の `[tool.ruff]` に集約されています。
 
 #### **基本的なコードチェック**
 
 プロジェクト全体をチェックします。
 
 ```bash
-flake8
+ruff check
 ```
 
-#### **最大行長を指定**
+#### **自動修正可能な問題を修正**
 
-Black と統一するために、最大行長を 88 文字に設定します（設定ファイルに記述しても OK）。
-
-```bash
-flake8 --max-line-length=88
-```
-
-#### **特定のルールを無視**
-
-Black と矛盾するルール（例: `E203`, `W503`）を無視して実行します。
+`--fix` オプションを使用すると、自動修正可能な問題を一括で修正します。
 
 ```bash
-flake8 --ignore=E203,W503
+ruff check --fix
 ```
 
 #### **特定のファイルのみをチェック**
@@ -150,38 +135,29 @@ flake8 --ignore=E203,W503
 特定のファイルやディレクトリだけをチェックします。
 
 ```bash
-flake8 src/fizzbuzz/fizzbuzz.py
-```
-
-#### **コード内の TODO や FIXME を確認**
-
-`--radar`や`--todo`プラグインを使用して、TODO コメントを含む箇所を一覧表示します（プラグインのインストールが必要）。
-
-```bash
-pip install flake8-todo
-flake8 --todo
+ruff check src/reference/samples/fizzbuzz/fizzbuzz.py
 ```
 
 ---
 
-### **3. コードのフォーマット**
+### **3. コードのフォーマット (Ruff)**
 
-`black`を使用してコードを自動整形します。
+`ruff format` を使用してコードを自動整形します。Ruff のフォーマッタは Black 互換の挙動です。
 
 #### **プロジェクト全体をフォーマット**
 
 プロジェクト内のすべての Python ファイルをフォーマットします。
 
 ```bash
-black .
+ruff format .
 ```
 
 #### **変更内容をプレビュー**
 
-`--check`オプションを使用すると、フォーマットの提案内容だけを確認できます（実際の変更は行われません）。
+`--check` オプションを使用すると、フォーマットの提案内容だけを確認できます（実際の変更は行われません）。
 
 ```bash
-black --check .
+ruff format --check .
 ```
 
 #### **特定のファイルやディレクトリだけをフォーマット**
@@ -189,18 +165,15 @@ black --check .
 特定の範囲だけを対象にする場合、パスを指定します。
 
 ```bash
-black src/fizzbuzz/fizzbuzz.py
+ruff format src/reference/samples/fizzbuzz/fizzbuzz.py
 ```
 
-## **カスタマイズ**:
+## **カスタマイズ**
 
-- `.devcontainer/devcontainer.json` ファイルを編集することで、開発環境をカスタマイズできます。
-- 例えば、Python のバージョン変更や追加ツールのインストールが可能です。
+- `.devcontainer/devcontainer.json` で VS Code 拡張や `remoteUser` を編集できます。
+- `.devcontainer/Dockerfile` で Python のバージョンや追加する OS パッケージを変更できます。
+- `requirements.txt` を変更した場合は Devcontainer をリビルドすることで反映されます（VS Code: `Dev Containers: Rebuild Container`）。
 
 ## ライセンス
 
 このプロジェクトは MIT ライセンスの下で提供されています。
-
-```
-
-```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.ruff]
+line-length = 88
+target-version = "py313"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pytest
-black
-flake8
+ruff


### PR DESCRIPTION
## Summary

- Python 3.11 → **3.13** にアップデート、Dockerfile の apt 重複インストールを整理、非 root ユーザー (`vscode`) で動作するように変更
- lint/format を flake8 + black → **Ruff 一本化**、設定は `pyproject.toml` に集約 (`.flake8` を削除)
- `.dockerignore` を追加して build context を縮小、VS Code では保存時に Ruff の整形と自動 fix が走るよう設定
- README のファイルパス誤記（`test_conditions.py` など）と古いブランチ指定を修正、`hello_world` と `observer_property` を追記

## 主な変更ファイル

| 種別 | ファイル |
|---|---|
| 更新 | `.devcontainer/Dockerfile`, `.devcontainer/devcontainer.json`, `requirements.txt`, `.vscode/settings.json`, `README.md` |
| 新規 | `pyproject.toml`, `.dockerignore` |
| 削除 | `.flake8` |

## Test plan

- [x] `Dev Containers: Rebuild Container` でビルド成功
- [x] コンテナ内で `python --version` が `Python 3.13.x`
- [x] コンテナ内で `whoami` が `vscode`
- [x] `pytest` で既存テスト全パス
- [x] `ruff check` / `ruff format --check .` の動作確認
- [x] VS Code で Python ファイル保存時に Ruff 自動整形・自動 fix が走ること
- [x] GitHub Codespaces での動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)